### PR TITLE
intercom-settings.yaml: consistent wording "Indoor Station"

### DIFF
--- a/firmware/components/intercom-settings.yaml
+++ b/firmware/components/intercom-settings.yaml
@@ -38,7 +38,7 @@ select:
   - platform: tc_bus
     model:
       id: intercom_model
-      name: "Intercom Model"
+      name: "Indoor Station Model"
       icon: "mdi:doorbell-video"
       entity_category: CONFIG
       disabled_by_default: true


### PR DESCRIPTION
Both the settings UI and the Quickstart guide generally use "Indoor Station", as opposed to "Intercom". Let's use consistent wording here.