### PR TITLE
Update `esphome/build-action` to v7

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -66,7 +66,7 @@ jobs:
           TIMESTAMP=$(date +%d%H%M)
           sed -i '/^  project:/,/^  platformio_options:/s/^    version: .*/    version: "'"$VERSION"'-dev.'"$TIMESTAMP"'"/' firmware/base.yaml
 
-      - uses: esphome/build-action@v6.0.0
+      - uses: esphome/build-action@v7
         id: esphome-build
         with:
           yaml-file: ${{ matrix.file }}

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -14,21 +14,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Doorman Stock for Home Assistant (ESP32-S3) Firmware
-        uses: esphome/build-action@v6.0.0
+        uses: esphome/build-action@v7
         with:
           yaml-file: firmware/ha-doorman-stock.yaml
           version: latest
           complete-manifest: true
 
       - name: Build Doorman Nuki Bridge for Home Assistant (ESP32-S3) Firmware
-        uses: esphome/build-action@v6.0.0
+        uses: esphome/build-action@v7
         with:
           yaml-file: firmware/ha-doorman-nuki-bridge.yaml
           version: latest
           complete-manifest: true
 
       - name: Build Component Test (ESP8266) Firmware
-        uses: esphome/build-action@v6.0.0
+        uses: esphome/build-action@v7
         with:
           yaml-file: firmware/tc-bus-component-8266.yaml
           version: latest


### PR DESCRIPTION
Updates `esphome/build-action` from v6.0.0 to v7 in the CI workflows.

The nightly builds have been failing since May 11, 2025 with the error:
```
exec /entrypoint.py: no such file or directory
```

This appears to be caused by `build-action@v6.0.0` using a hardcoded shebang (`#!/usr/bin/python3`) that doesn't match the Python location in newer ESPHome Docker images. This was fixed in https://github.com/esphome/build-action/pull/78 by switching to `#!/usr/bin/env python3`, which is included in v6.0.1+ and v7.

Please note that I have not tested this locally.