### PR TITLE
feat(tc_bus_device): distinguish calls to the parallel serial number

### DIFF
--- a/components/tc_bus_device/binary_sensor/__init__.py
+++ b/components/tc_bus_device/binary_sensor/__init__.py
@@ -10,6 +10,7 @@ DoorOpenerBinarySensor = tc_bus_ns.class_("DoorOpenerBinarySensor", binary_senso
 
 CONF_ADDRESS = "address"
 CONF_PAYLOAD = "payload"
+CONF_SERIAL_NUMBER = "serial_number"
 CONF_NAME = "name"
 CONF_AUTO_OFF = "auto_off"
 CONF_SENSOR_TYPE = "sensor_type"
@@ -23,6 +24,7 @@ TELEGRAM_SCHEMA = binary_sensor.binary_sensor_schema(DeviceTelegramListenerBinar
         cv.Required(CONF_TYPE): cv.enum(TELEGRAM_TYPES, upper=False),
         cv.Optional(CONF_ADDRESS): cv.templatable(cv.hex_uint8_t),
         cv.Optional(CONF_PAYLOAD): cv.templatable(cv.hex_uint32_t),
+        cv.Optional(CONF_SERIAL_NUMBER): cv.templatable(cv.uint32_t),
         cv.Optional(CONF_ICON, default="mdi:doorbell"): cv.icon,
         cv.Optional(CONF_NAME, default="Doorbell"): cv.string,
         cv.Optional(CONF_AUTO_OFF, default="3s"): cv.positive_time_period_milliseconds
@@ -64,7 +66,11 @@ async def to_code(config):
         if CONF_PAYLOAD in config:
             telegram_payload = await cg.templatable(config[CONF_PAYLOAD], [], cg.uint32)
             cg.add(var.set_payload(telegram_payload))
-        
+
+        if CONF_SERIAL_NUMBER in config:
+            telegram_serial_number = await cg.templatable(config[CONF_SERIAL_NUMBER], [], cg.uint32)
+            cg.add(var.set_serial_number(telegram_serial_number))
+
         cg.add(var.set_auto_reset(config[CONF_AUTO_OFF]))
         cg.add(tc_bus_device.register_listener(var))
 

--- a/components/tc_bus_device/tc_bus_device.cpp
+++ b/components/tc_bus_device/tc_bus_device.cpp
@@ -1386,7 +1386,7 @@ namespace esphome::tc_bus
             bool allow_publish = (telegram_data.type == (listener->type_.value_or(TELEGRAM_TYPE_UNKNOWN))) &&
                 (telegram_data.address == listener->address_.value_or(0) || listener->address_.value_or(0) == 255) &&
                 (telegram_data.payload == listener->payload_.value_or(0) || listener->payload_.value_or(0) == 255) &&
-                (telegram_data.serial_number == this->serial_number_);
+                (telegram_data.serial_number == listener->serial_number_.value_or(this->serial_number_));
 
             // Trigger listener binary sensor if match found
             if (allow_publish)

--- a/components/tc_bus_device/tc_bus_device.h
+++ b/components/tc_bus_device/tc_bus_device.h
@@ -67,6 +67,7 @@ namespace esphome::tc_bus
         template<typename T> void set_type(T type) { this->type_ = type; }
         template<typename T> void set_address(T address) { this->address_ = address; }
         template<typename T> void set_payload(T payload) { this->payload_ = payload; }
+        template<typename T> void set_serial_number(T serial_number) { this->serial_number_ = serial_number; }
 
         void set_auto_reset(uint16_t auto_reset) { this->auto_reset_ = auto_reset; }
 
@@ -79,6 +80,9 @@ namespace esphome::tc_bus
         TemplatableValue<TelegramType> type_{};
         TemplatableValue<uint8_t> address_{};
         TemplatableValue<uint32_t> payload_{};
+
+        // Unset means the device's own serial number
+        TemplatableValue<uint32_t> serial_number_{};
     };
 #endif
 

--- a/docs/de/reference/entities-tc-bus.md
+++ b/docs/de/reference/entities-tc-bus.md
@@ -6,11 +6,20 @@ On this page, you can view all the entities related to TC:BUS.
 ### Entrance Doorbell <Badge type="tip" text="entrance_doorbell" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `door_call` telegram type with the entrance door station `address` is received.
 
+### Entrance Doorbell (Parallel) <Badge type="tip" text="entrance_doorbell_parallel" /> <Badge type="info" text="Disabled by default" />
+Activates whenever the `door_call` telegram type with the entrance door station `address` is received, addressed to the `parallel_serial_number` instead of the serial number of the indoor station. Hidden while no parallel serial number is set.
+
 ### Second Entrance Doorbell <Badge type="tip" text="second_entrance_doorbell" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `door_call` telegram type with the second entrance door station `address` is received.
 
+### Second Entrance Doorbell (Parallel) <Badge type="tip" text="second_entrance_doorbell_parallel" /> <Badge type="info" text="Disabled by default" />
+Activates whenever the `door_call` telegram type with the second entrance door station `address` is received, addressed to the `parallel_serial_number` instead of the serial number of the indoor station. Hidden while no parallel serial number is set.
+
 ### Apartment Doorbell <Badge type="tip" text="apartment_doorbell" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `floor_call` telegram type is received.
+
+### Apartment Doorbell (Parallel) <Badge type="tip" text="apartment_doorbell_parallel" /> <Badge type="info" text="Disabled by default" />
+Activates whenever the `floor_call` telegram type is received, addressed to the `parallel_serial_number` instead of the serial number of the indoor station. Hidden while no parallel serial number is set.
 
 ### Pick up phone <Badge type="tip" text="pick_up_phone" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `start_talking` telegram type is received.
@@ -258,29 +267,47 @@ Represents the second entrance door of the building. Only the `Open` and `Unlock
 ### Entrance Doorbell <Badge type="tip" text="entrance_doorbell_pattern" />
 Triggers each time a doorbell pattern is detected at the entrance. Learn more about pattern events [here](../guide/features/pattern-events).
 
+The `parallel_` event types are triggered when the call was addressed to the parallel serial number instead of the serial number of the indoor station.
+
 ##### Event Types
 - **single**
 - **double**
 - **triple**
 - **quadruple**
+- **parallel_single**
+- **parallel_double**
+- **parallel_triple**
+- **parallel_quadruple**
 
 ### Second Entrance Doorbell <Badge type="tip" text="second_entrance_doorbell_pattern" /> <Badge type="info" text="Disabled by default" />
 Triggers each time a doorbell pattern is detected at the second entrance. Learn more about pattern events [here](../guide/features/pattern-events).
 
+The `parallel_` event types are triggered when the call was addressed to the parallel serial number instead of the serial number of the indoor station.
+
 ##### Event Types
 - **single**
 - **double**
 - **triple**
 - **quadruple**
+- **parallel_single**
+- **parallel_double**
+- **parallel_triple**
+- **parallel_quadruple**
 
 ### Apartment Doorbell <Badge type="tip" text="apartment_doorbell_pattern" />
 Triggers each time a doorbell pattern is detected at the apartment. Learn more about pattern events [here](../guide/features/pattern-events).
 
+The `parallel_` event types are triggered when the call was addressed to the parallel serial number instead of the serial number of the indoor station.
+
 ##### Event Types
 - **single**
 - **double**
 - **triple**
 - **quadruple**
+- **parallel_single**
+- **parallel_double**
+- **parallel_triple**
+- **parallel_quadruple**
 
 ### Phone pick up <Badge type="tip" text="phone_pick_up_pattern" /> <Badge type="info" text="Disabled by default" />
 Triggers each time a phone pick up pattern is detected. Learn more about pattern events [here](../guide/features/pattern-events).

--- a/docs/en/reference/entities-tc-bus.md
+++ b/docs/en/reference/entities-tc-bus.md
@@ -10,11 +10,20 @@ On this page, you can view all the entities related to TC:BUS.
 ### Entrance Doorbell <Badge type="tip" text="entrance_doorbell" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `door_call` telegram type with the entrance door station `address` is received.
 
+### Entrance Doorbell (Parallel) <Badge type="tip" text="entrance_doorbell_parallel" /> <Badge type="info" text="Disabled by default" />
+Activates whenever the `door_call` telegram type with the entrance door station `address` is received, addressed to the `parallel_serial_number` instead of the serial number of the indoor station. Hidden while no parallel serial number is set.
+
 ### Second Entrance Doorbell <Badge type="tip" text="second_entrance_doorbell" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `door_call` telegram type with the second entrance door station `address` is received.
 
+### Second Entrance Doorbell (Parallel) <Badge type="tip" text="second_entrance_doorbell_parallel" /> <Badge type="info" text="Disabled by default" />
+Activates whenever the `door_call` telegram type with the second entrance door station `address` is received, addressed to the `parallel_serial_number` instead of the serial number of the indoor station. Hidden while no parallel serial number is set.
+
 ### Apartment Doorbell <Badge type="tip" text="apartment_doorbell" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `floor_call` telegram type is received.
+
+### Apartment Doorbell (Parallel) <Badge type="tip" text="apartment_doorbell_parallel" /> <Badge type="info" text="Disabled by default" />
+Activates whenever the `floor_call` telegram type is received, addressed to the `parallel_serial_number` instead of the serial number of the indoor station. Hidden while no parallel serial number is set.
 
 ### Pick up phone <Badge type="tip" text="pick_up_phone" /> <Badge type="info" text="Disabled by default" />
 Activates whenever the `start_talking` telegram type is received.
@@ -262,29 +271,47 @@ Represents the second entrance door of the building. Only the `Open` and `Unlock
 ### Entrance Doorbell <Badge type="tip" text="entrance_doorbell_pattern" />
 Triggers each time a doorbell pattern is detected at the entrance. Learn more about pattern events [here](../guide/features/pattern-events).
 
+The `parallel_` event types are triggered when the call was addressed to the parallel serial number instead of the serial number of the indoor station.
+
 ##### Event Types
 - **single**
 - **double**
 - **triple**
 - **quadruple**
+- **parallel_single**
+- **parallel_double**
+- **parallel_triple**
+- **parallel_quadruple**
 
 ### Second Entrance Doorbell <Badge type="tip" text="second_entrance_doorbell_pattern" /> <Badge type="info" text="Disabled by default" />
 Triggers each time a doorbell pattern is detected at the second entrance. Learn more about pattern events [here](../guide/features/pattern-events).
 
+The `parallel_` event types are triggered when the call was addressed to the parallel serial number instead of the serial number of the indoor station.
+
 ##### Event Types
 - **single**
 - **double**
 - **triple**
 - **quadruple**
+- **parallel_single**
+- **parallel_double**
+- **parallel_triple**
+- **parallel_quadruple**
 
 ### Apartment Doorbell <Badge type="tip" text="apartment_doorbell_pattern" />
 Triggers each time a doorbell pattern is detected at the apartment. Learn more about pattern events [here](../guide/features/pattern-events).
 
+The `parallel_` event types are triggered when the call was addressed to the parallel serial number instead of the serial number of the indoor station.
+
 ##### Event Types
 - **single**
 - **double**
 - **triple**
 - **quadruple**
+- **parallel_single**
+- **parallel_double**
+- **parallel_triple**
+- **parallel_quadruple**
 
 ### Phone pick up <Badge type="tip" text="phone_pick_up_pattern" /> <Badge type="info" text="Disabled by default" />
 Triggers each time a phone pick up pattern is detected. Learn more about pattern events [here](../guide/features/pattern-events).

--- a/docs/en/reference/esphome-component-device.md
+++ b/docs/en/reference/esphome-component-device.md
@@ -120,6 +120,7 @@ This sensor type supports advanced triggering options, enabling it to respond to
 | `type`           | Telegram type that will trigger the binary sensor, used alongside `address` and `payload`.               | ✅ |      |
 | `address`        | 8-bit address that serves as a condition to trigger the binary sensor. If you set it to `255`, it will catch all addresses. | | `0`           |
 | `payload`        | 32-bit payload that serves as a condition to trigger the binary sensor.                                  | | `0`           |
+| `serial_number`  | 20-bit serial number that serves as a condition to trigger the binary sensor. Defaults to the serial number of the device itself, so the sensor only reacts to telegrams addressed to it. Set it to the `parallel_serial_number` to react to calls addressed to the parallel serial number instead. | | Device serial number |
 
 ### Sensor Type: `virtual_door_opener`
 This sensor type replaces the physical door opener when using a virtual outdoor station.

--- a/firmware/packages/bus_devices/indoor-station-settings.yaml
+++ b/firmware/packages/bus_devices/indoor-station-settings.yaml
@@ -84,6 +84,8 @@ number:
       entity_category: CONFIG
       icon: "mdi:barcode-scan"
       #disabled_by_default: true
+      on_value:
+        - script.execute: set_unused_entities_internal
       web_server:
         sorting_group_id: sorting_group_setup_indoor_station
         sorting_weight: -99

--- a/firmware/packages/common/base.yaml
+++ b/firmware/packages/common/base.yaml
@@ -537,6 +537,20 @@ binary_sensor:
 
   - platform: tc_bus_device
     tc_bus_device_id: tc_bus_indoor_station
+    id: entrance_doorbell_parallel
+    device_id: tc_bus_is
+    name: "Entrance Doorbell (Parallel)"
+    type: door_call
+    address: !lambda "return id(entrance_door_station_address).state;"
+    serial_number: !lambda "return id(indoor_station_parallel_sn).state;"
+    auto_off: 0.2s
+    disabled_by_default: true
+    web_server:
+      sorting_group_id: sorting_group_diagnostics_listeners
+      sorting_weight: 212
+
+  - platform: tc_bus_device
+    tc_bus_device_id: tc_bus_indoor_station
     id: second_entrance_doorbell
     device_id: tc_bus_is
     name: "Second Entrance Doorbell"
@@ -550,6 +564,20 @@ binary_sensor:
 
   - platform: tc_bus_device
     tc_bus_device_id: tc_bus_indoor_station
+    id: second_entrance_doorbell_parallel
+    device_id: tc_bus_is
+    name: "Second Entrance Doorbell (Parallel)"
+    type: door_call
+    address: !lambda "return id(second_entrance_door_station_address).state;"
+    serial_number: !lambda "return id(indoor_station_parallel_sn).state;"
+    auto_off: 0.2s
+    disabled_by_default: true
+    web_server:
+      sorting_group_id: sorting_group_diagnostics_listeners
+      sorting_weight: 222
+
+  - platform: tc_bus_device
+    tc_bus_device_id: tc_bus_indoor_station
     id: apartment_doorbell
     device_id: tc_bus_is
     name: "Apartment Doorbell"
@@ -559,6 +587,19 @@ binary_sensor:
     web_server:
       sorting_group_id: sorting_group_diagnostics_listeners
       sorting_weight: 230
+
+  - platform: tc_bus_device
+    tc_bus_device_id: tc_bus_indoor_station
+    id: apartment_doorbell_parallel
+    device_id: tc_bus_is
+    name: "Apartment Doorbell (Parallel)"
+    type: floor_call
+    serial_number: !lambda "return id(indoor_station_parallel_sn).state;"
+    auto_off: 0.2s
+    disabled_by_default: true
+    web_server:
+      sorting_group_id: sorting_group_diagnostics_listeners
+      sorting_weight: 232
 
   - platform: tc_bus_device
     tc_bus_device_id: tc_bus_indoor_station
@@ -797,6 +838,15 @@ script:
           id(second_entrance_door_before_open_cmds)->set_internal(internal);
           id(second_entrance_doorbell)->set_internal(internal);
           id(second_entrance_doorbell_pattern)->set_internal(internal);
+
+      # Set parallel serial number listeners internal if no parallel serial number is set
+      - lambda: |-
+          float parallel_sn = id(indoor_station_parallel_sn).state;
+          bool no_parallel_sn = parallel_sn <= 0 || parallel_sn >= 1000000;
+          bool no_second_entrance = id(second_entrance_door_station_address).state == 63 || id(second_entrance_door_station_address).state == id(entrance_door_station_address).state;
+          id(entrance_doorbell_parallel)->set_internal(no_parallel_sn);
+          id(second_entrance_doorbell_parallel)->set_internal(no_parallel_sn || no_second_entrance);
+          id(apartment_doorbell_parallel)->set_internal(no_parallel_sn);
 
   - id: blink_red_status_led
     mode: restart

--- a/firmware/packages/pattern_events/doorbell-pattern.yaml
+++ b/firmware/packages/pattern_events/doorbell-pattern.yaml
@@ -1,0 +1,75 @@
+# Doorbell Pattern Template
+#
+# Detects single/double/triple/quadruple ring patterns on one doorbell listener
+# and forwards them to an event entity. Instantiated once per listener from
+# pattern-events.yaml.
+#
+# Parameters:
+#   sensor_id      - binary sensor to attach the pattern detection to
+#   event_id       - event entity the detected pattern is fired on
+#   trigger_prefix - unique prefix for the generated multi click trigger ids
+#   event_prefix   - prepended to the event type, e.g. "parallel_"
+
+binary_sensor:
+  - id: !extend ${sensor_id}
+    on_multi_click:
+      # Single press
+      - timing:
+          - ON for at most 0.5s
+          - OFF for at least 1.8s
+        trigger_id: ${trigger_prefix}_pattern_single
+        then:
+          - event.trigger:
+              id: ${event_id}
+              event_type: ${event_prefix}single
+
+      # Double press
+      - timing:
+          - ON for at most 0.5s
+          - OFF for at most 1s
+
+          - ON for at most 0.5s
+          - OFF for at least 1.7s
+        trigger_id: ${trigger_prefix}_pattern_double
+        then:
+          - lambda: !lambda "id(${trigger_prefix}_pattern_single).cancel();"
+          - event.trigger:
+              id: ${event_id}
+              event_type: ${event_prefix}double
+
+      # Triple press
+      - timing:
+          - ON for at most 0.5s
+          - OFF for at most 1s
+
+          - ON for at most 0.5s
+          - OFF for at most 1s
+
+          - ON for at most 0.5s
+          - OFF for at least 1.6s
+        trigger_id: ${trigger_prefix}_pattern_triple
+        then:
+          - lambda: !lambda "id(${trigger_prefix}_pattern_single).cancel();"
+          - event.trigger:
+              id: ${event_id}
+              event_type: ${event_prefix}triple
+
+      # Quadruple press
+      - timing:
+          - ON for at most 0.5s
+          - OFF for at most 1s
+
+          - ON for at most 0.5s
+          - OFF for at most 1s
+
+          - ON for at most 0.5s
+          - OFF for at most 1s
+
+          - ON for at most 0.5s
+          - OFF for at least 1.5s
+        trigger_id: ${trigger_prefix}_pattern_quadruple
+        then:
+          - lambda: !lambda "id(${trigger_prefix}_pattern_single).cancel();"
+          - event.trigger:
+              id: ${event_id}
+              event_type: ${event_prefix}quadruple

--- a/firmware/packages/pattern_events/pattern-events.yaml
+++ b/firmware/packages/pattern_events/pattern-events.yaml
@@ -1,6 +1,7 @@
 # Pattern Events Addon
 
 packages:
+  # Entrance Doorbell
   entrance_doorbell_pattern: !include
     file: doorbell-pattern.yaml
     vars:
@@ -9,6 +10,15 @@ packages:
       trigger_prefix: edb
       event_prefix: ""
 
+  entrance_doorbell_parallel_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: entrance_doorbell_parallel
+      event_id: entrance_doorbell_pattern
+      trigger_prefix: edbp
+      event_prefix: "parallel_"
+
+  # Second Entrance Doorbell
   second_entrance_doorbell_pattern: !include
     file: doorbell-pattern.yaml
     vars:
@@ -17,6 +27,15 @@ packages:
       trigger_prefix: sedb
       event_prefix: ""
 
+  second_entrance_doorbell_parallel_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: second_entrance_doorbell_parallel
+      event_id: second_entrance_doorbell_pattern
+      trigger_prefix: sedbp
+      event_prefix: "parallel_"
+
+  # Apartment Doorbell
   apartment_doorbell_pattern: !include
     file: doorbell-pattern.yaml
     vars:
@@ -25,6 +44,15 @@ packages:
       trigger_prefix: adb
       event_prefix: ""
 
+  apartment_doorbell_parallel_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: apartment_doorbell_parallel
+      event_id: apartment_doorbell_pattern
+      trigger_prefix: adbp
+      event_prefix: "parallel_"
+
+  # Phone pick up
   phone_pick_up_pattern: !include
     file: doorbell-pattern.yaml
     vars:
@@ -40,6 +68,10 @@ event:
       - "double"
       - "triple"
       - "quadruple"
+      - "parallel_single"
+      - "parallel_double"
+      - "parallel_triple"
+      - "parallel_quadruple"
 
   - id: !extend second_entrance_doorbell_pattern
     event_types:
@@ -47,6 +79,10 @@ event:
       - "double"
       - "triple"
       - "quadruple"
+      - "parallel_single"
+      - "parallel_double"
+      - "parallel_triple"
+      - "parallel_quadruple"
 
   - id: !extend apartment_doorbell_pattern
     event_types:
@@ -54,6 +90,10 @@ event:
       - "double"
       - "triple"
       - "quadruple"
+      - "parallel_single"
+      - "parallel_double"
+      - "parallel_triple"
+      - "parallel_quadruple"
 
   - id: !extend phone_pick_up_pattern
     event_types:

--- a/firmware/packages/pattern_events/pattern-events.yaml
+++ b/firmware/packages/pattern_events/pattern-events.yaml
@@ -1,5 +1,38 @@
 # Pattern Events Addon
 
+packages:
+  entrance_doorbell_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: entrance_doorbell
+      event_id: entrance_doorbell_pattern
+      trigger_prefix: edb
+      event_prefix: ""
+
+  second_entrance_doorbell_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: second_entrance_doorbell
+      event_id: second_entrance_doorbell_pattern
+      trigger_prefix: sedb
+      event_prefix: ""
+
+  apartment_doorbell_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: apartment_doorbell
+      event_id: apartment_doorbell_pattern
+      trigger_prefix: adb
+      event_prefix: ""
+
+  phone_pick_up_pattern: !include
+    file: doorbell-pattern.yaml
+    vars:
+      sensor_id: pick_up_phone
+      event_id: phone_pick_up_pattern
+      trigger_prefix: ppu
+      event_prefix: ""
+
 event:
   - id: !extend entrance_doorbell_pattern
     event_types:
@@ -28,256 +61,3 @@ event:
       - "double"
       - "triple"
       - "quadruple"
-
-binary_sensor:
-  - id: !extend entrance_doorbell
-    on_multi_click:
-      # Single press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at least 1.8s
-        trigger_id: edb_pattern_single
-        then:
-          - event.trigger:
-              id: entrance_doorbell_pattern
-              event_type: single
-
-      # Double press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.7s
-        trigger_id: edb_pattern_double
-        then:
-          - lambda: !lambda "id(edb_pattern_single).cancel();"
-          - event.trigger:
-              id: entrance_doorbell_pattern
-              event_type: double
-              
-      # Triple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.6s
-        trigger_id: edb_pattern_triple
-        then:
-          - lambda: !lambda "id(edb_pattern_single).cancel();"
-          - event.trigger:
-              id: entrance_doorbell_pattern
-              event_type: triple
-
-      # Quadruple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.5s
-        trigger_id: edb_pattern_quadruple
-        then:
-          - lambda: !lambda "id(edb_pattern_single).cancel();"
-          - event.trigger:
-              id: entrance_doorbell_pattern
-              event_type: quadruple
-
-  - id: !extend second_entrance_doorbell
-    on_multi_click:
-      # Single press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at least 1.8s
-        trigger_id: sedb_pattern_single
-        then:
-          - event.trigger:
-              id: second_entrance_doorbell_pattern
-              event_type: single
-
-      # Double press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.7s
-        trigger_id: sedb_pattern_double
-        then:
-          - lambda: !lambda "id(sedb_pattern_single).cancel();"
-          - event.trigger:
-              id: second_entrance_doorbell_pattern
-              event_type: double
-              
-      # Triple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.6s
-        trigger_id: sedb_pattern_triple
-        then:
-          - lambda: !lambda "id(sedb_pattern_single).cancel();"
-          - event.trigger:
-              id: second_entrance_doorbell_pattern
-              event_type: triple
-
-      # Quadruple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.5s
-        trigger_id: sedb_pattern_quadruple
-        then:
-          - lambda: !lambda "id(sedb_pattern_single).cancel();"
-          - event.trigger:
-              id: second_entrance_doorbell_pattern
-              event_type: quadruple
-
-  - id: !extend apartment_doorbell
-    on_multi_click:
-      # Single press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at least 1.8s
-        trigger_id: adb_pattern_single
-        then:
-          - event.trigger:
-              id: apartment_doorbell_pattern
-              event_type: single
-
-      # Double press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.7s
-        trigger_id: adb_pattern_double
-        then:
-          - lambda: !lambda "id(adb_pattern_single).cancel();"
-          - event.trigger:
-              id: apartment_doorbell_pattern
-              event_type: double
-              
-      # Triple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.6s
-        trigger_id: adb_pattern_triple
-        then:
-          - lambda: !lambda "id(adb_pattern_single).cancel();"
-          - event.trigger:
-              id: apartment_doorbell_pattern
-              event_type: triple
-
-      # Quadruple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.5s
-        trigger_id: adb_pattern_quadruple
-        then:
-          - lambda: !lambda "id(adb_pattern_single).cancel();"
-          - event.trigger:
-              id: apartment_doorbell_pattern
-              event_type: quadruple
-
-  - id: !extend pick_up_phone
-    on_multi_click:
-      # Single press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at least 1.8s
-        trigger_id: ppu_pattern_single
-        then:
-          - event.trigger:
-              id: phone_pick_up_pattern
-              event_type: single
-
-      # Double press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.7s
-        trigger_id: ppu_pattern_double
-        then:
-          - lambda: !lambda "id(ppu_pattern_single).cancel();"
-          - event.trigger:
-              id: phone_pick_up_pattern
-              event_type: double
-              
-      # Triple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.6s
-        trigger_id: ppu_pattern_triple
-        then:
-          - lambda: !lambda "id(ppu_pattern_single).cancel();"
-          - event.trigger:
-              id: phone_pick_up_pattern
-              event_type: triple
-
-      # Quadruple press
-      - timing:
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at most 1s
-
-          - ON for at most 0.5s
-          - OFF for at least 1.5s
-        trigger_id: ppu_pattern_quadruple
-        then:
-          - lambda: !lambda "id(ppu_pattern_single).cancel();"
-          - event.trigger:
-              id: phone_pick_up_pattern
-              event_type: quadruple


### PR DESCRIPTION
Indoor-station listeners only matched calls addressed to the device's own serial, since the telegram serial was compared against `this->serial_number_` directly. Calls to a flat's **parallel serial** are handled in the call-answering path but never reach the listeners, so entrance calls to a parallel-serial flat never fire the Entrance Doorbell — and thus never fire the `event` that HA automations key off.

Adds an optional `serial_number` filter to the telegram binary sensor, alongside the existing `type`, `address` and `payload`. Unset means the device's own serial, so existing listeners are unaffected. Each of the three doorbells gets a parallel counterpart, which fires the *existing* event entity with `parallel_` prefixed event types rather than duplicating it, per @AzonInc's suggestion.

Confirmed on a TCS VTC42V2 whose entrance calls arrive on its parallel serial: the Entrance Doorbell never fired despite the handset chiming, while the Apartment Doorbell (main serial) worked normally.
