### PR TITLE
fix(siedle_in_home_bus): enable esp_timer ISR dispatch via sdkconfig

### DIFF
--- a/components/siedle_in_home_bus/__init__.py
+++ b/components/siedle_in_home_bus/__init__.py
@@ -1,4 +1,5 @@
 from esphome import automation, pins
+from esphome.components.esp32 import add_idf_sdkconfig_option
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_RX_PIN, CONF_TX_PIN, CONF_DUMP, CONF_COMMAND, CONF_SOURCE
@@ -6,10 +7,6 @@ from esphome.const import CONF_ID, CONF_RX_PIN, CONF_TX_PIN, CONF_DUMP, CONF_COM
 CODEOWNERS = []
 MULTI_CONF = True
 CONF_SIEDLE_IN_HOME_BUS_ID = "siedle_in_home_bus_id"
-
-# Required for ESP_TIMER_ISR dispatch mode
-cg.add_define("CONFIG_ESP_TIMER_IN_IRAM", 1)
-cg.add_define("CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD", 1)
 
 siedle_in_home_bus_ns = cg.esphome_ns.namespace("siedle_in_home_bus")
 SiedleInHomeBusComponent = siedle_in_home_bus_ns.class_("SiedleInHomeBusComponent", cg.Component)
@@ -51,6 +48,11 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
+    # Required for ESP_TIMER_ISR dispatch mode: must be set in the IDF sdkconfig
+    # (a cg.add_define() only injects a C #define and does not enable the Kconfig option)
+    add_idf_sdkconfig_option("CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD", True)
+    add_idf_sdkconfig_option("CONFIG_ESP_TIMER_IN_IRAM", True)
+
     cg.add_global(siedle_in_home_bus_ns.using)
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)


### PR DESCRIPTION
## Problem
On the Doorman S3 (hw rev 2.2.0, ESP32-S3) the `siedle_in_home_bus` receiver was completely silent — no telegrams were ever decoded.

## Root cause
`__init__.py` enabled ESP_TIMER ISR-dispatch mode with two module-level `cg.add_define()` calls:

    cg.add_define("CONFIG_ESP_TIMER_IN_IRAM", 1)
    cg.add_define("CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD", 1)

`cg.add_define()` only injects a C `#define` into the generated code — it does **not** set the ESP-IDF Kconfig option. So `sdkconfig` kept `# CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD is not set`. The prebuilt `esp_timer` library was compiled with `esp_timer_dispatch_t` ending at `ESP_TIMER_MAX = 1`, while the component translation unit (seeing the #define) used `ESP_TIMER_ISR = 2`. `esp_timer_create()` with `.dispatch_method = ESP_TIMER_ISR` then returned `ESP_ERR_INVALID_ARG` (the return value is unchecked), so `store_.bus_timer` stayed `nullptr`. The carrier GPIO ISR latched `status = RECEIVING` on the first edge and, with no timer to start, never sampled again — total silence.

## Fix
Set both options through `add_idf_sdkconfig_option()` inside `to_code()` so they actually land in the IDF `sdkconfig`.

## Testing
Confirmed on hardware (Doorman S3, hw rev 2.2.0). After this change the receiver decodes live Siedle In-Home-Bus telegrams (e.g. `Received Command: 0x0C`, ring commands, etc.) where before it logged nothing.